### PR TITLE
Update site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ email: voxproduct@voxmedia.com
 description: > # this means to ignore newlines until "baseurl:"
   As journalists, advertisers, producers, and creators, content is at our core at Vox Media. We want to ensure that everyone—regardless of ability, situation, or context—can access it.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://accessibility.voxmedia.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
Right now, both the RSS and canonical links in the `head` are incorrect:

```html
<link rel="canonical" href="http://yourdomain.com/">
<link rel="alternate" type="application/rss+xml" title="Vox Product Accessibility Guidelines" href="http://yourdomain.com/feed.xml">
```

This PR updates the `site.url` variable, which is used to generate those URL's.