### PR TITLE
Add lang attribute to default template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   {% include head.html %}
   <body>
     {{ content }}


### PR DESCRIPTION
A quick win that can bring greater a11y to the project :) Thanks for your efforts!

User agents and assistive technology can render text more accurately when a language is added to the `<html>` tag in the form of an attribute: `<html lang="en">`

[This video demonstrates the benefits for screen reader users](https://www.youtube.com/watch?v=ox5QVbZSPBk)

This is also required to meet [WCAG 2.0 3.1.1 Language of a Page](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html)

I'd be happy to make a PR for adding this to the checklist as it is very common for engineers to miss this one.


