### PR TITLE
Replaced WCAG 2.0 guidelines link with updated 2.1 quickref

### DIFF
--- a/_includes/tools.html
+++ b/_includes/tools.html
@@ -7,7 +7,7 @@
         <p>Use these tools to help make your work accessible </p>
       </label>
       <div id="tool-links">
-      	<p><a href="http://code.viget.com/interactive-wcag/#responsibility=design&level=aa">WCAG 2.0 guidelines to review best practices</a></p>
+      	<p><a href="https://www.w3.org/WAI/WCAG21/quickref/">WCAG 2.1 guidelines to review best practices</a></p>
   		  <p><a href="https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US">WAVE (Web Accessibility Evaluation Tool) Chrome Extension to check accessibility across your products</a></p>
         <p><a href="http://achecker.ca/checker/index.php">Web Accessibility Checker to check accessibility across your products</a></p>
   		  <p><a href="https://www.paciellogroup.com/resources/contrastanalyser/">Color Contrast Analyzer App to analyze color contrast</a></p>


### PR DESCRIPTION
The old link wasn't active anymore, and it was pointing to the 2.1 quickref.